### PR TITLE
空文字列を受けたときのDate.parse がArgmentError を返さない

### DIFF
--- a/lib/wareki/date.rb
+++ b/lib/wareki/date.rb
@@ -24,7 +24,8 @@ module Wareki
     end
 
     def self._parse(str)
-      match = REGEX.match(str.to_s.gsub(/[[:space:]]/, '')) or
+      str = str.to_s.gsub(/[[:space:]]/, '')
+      match = (!str.empty? && REGEX.match(str)) or
         raise ArgumentError, "Invaild Date: #{str}"
       era = match[:era_name]
       if (era.nil? || era == '') && match[:year].nil?

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -163,6 +163,10 @@ describe Wareki::Date do
     expect(d.parse("\t\n　1 9 2 8 年 3 月　１１ 日  ").to_date).to eq exd
   end
 
+  it "raise ArgumentError on parse empty string" do
+    expect { Date.parse('') }.to raise_error(ArgumentError)
+  end
+
   it "can parse date string without year" do
     today = Date.today
     d = Wareki::Date


### PR DESCRIPTION
空文字列を `Date.parse` した場合 標準の Dare.parse はArgemntError を返却するのですが、
0.4.0 にて変更になり今日を返却するようになってしまいました

検証コード
```
ruby -v
ruby 2.6.1p33 (2019-01-30 revision 66950) [x86_64-darwin18]
```

素のruby では Date.parse("") はArgumentError

```
wareki(master): irb
irb(main):001:0> require "time"
=> true
irb(main):002:0> Date.parse("")
Traceback (most recent call last):
        5: from /Users/katsusuke/.rbenv/versions/2.6.1/bin/irb:23:in `<main>'
        4: from /Users/katsusuke/.rbenv/versions/2.6.1/bin/irb:23:in `load'
        3: from /Users/katsusuke/.rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in `<top (required)>'
        2: from (irb):2
        1: from (irb):2:in `parse'
ArgumentError (invalid date)
```

wareki を読み込むと今日を返却してしまう
```
wareki(master): bin/console
irb(main):001:0> Date.parse("")
=> #<Date: 2019-01-01 ((2458485j,0s,0n),+0s,2299161j)>
```

cf:
https://github.com/sugi/wareki/commit/3c594d4cfddd64015461653b66fab3be2133f414