### PR TITLE
Support number format option. (#11)

### DIFF
--- a/lib/wareki/date.rb
+++ b/lib/wareki/date.rb
@@ -159,16 +159,18 @@ module Wareki
     end
 
     def strftime(format_str = '%JF')
-      ret = format_str.to_str.gsub(/%J([fFyYegGoOiImMsSlLdD][kK]?)/) { format($1) || $& }
+      ret = format_str.to_str.gsub(/%J(-|[_0]?[0-9]+|)([fFyYegGoOiImMsSlLdD][kK]?)/) { format($2, $1) || $& }
       ret.index('%') or return ret
       d = to_date
       d.respond_to?(:_wareki_strftime_orig) ? d._wareki_strftime_orig(ret) : d.strftime(ret)
     end
 
-    def format(key)
+    def format(key, opt = "")
+      sprintf_format = (opt.empty? ? "%02d" : "%#{opt.sub('_', '')}d")
+
       case key.to_sym
       when :e  then era_name
-      when :g  then era_name.to_s == '' ? '' : era_year
+      when :g  then era_name.to_s == '' ? '' : (sprintf_format % era_year)
       when :G  then era_name.to_s == '' ? '' : Utils.i2z(era_year)
       when :Gk then era_name.to_s == '' ? '' : YaKansuji.to_kan(era_year, :simple)
       when :GK
@@ -185,14 +187,14 @@ module Wareki
       when :i  then imperial_year
       when :I  then Utils.i2z(imperial_year)
       when :Ik then YaKansuji.to_kan(imperial_year, :simple)
-      when :s  then month
+      when :s  then (sprintf_format % month)
       when :S  then Utils.i2z(month)
       when :Sk then YaKansuji.to_kan(month, :simple)
       when :SK then Utils.alt_month_name(month)
       when :l  then leap_month? ? "'" : ''
       when :L  then leap_month? ? '’' : ''
       when :Lk then leap_month? ? '閏' : ''
-      when :d  then day
+      when :d  then (sprintf_format % day)
       when :D  then Utils.i2z(day)
       when :Dk then YaKansuji.to_kan(day, :simple)
       when :DK
@@ -205,14 +207,14 @@ module Wareki
         else
           YaKansuji.to_kan(day, :simple)
         end
-      when :m  then "#{format(:s)}#{format(:l)}"
+      when :m  then "#{format(:s, opt)}#{format(:l)}"
       when :M  then "#{format(:Lk)}#{format(:S)}"
       when :Mk then "#{format(:Lk)}#{format(:Sk)}"
-      when :y  then "#{format(:e)}#{format(:g)}"
+      when :y  then "#{format(:e)}#{format(:g, opt)}"
       when :Y  then "#{format(:e)}#{format(:G)}"
       when :Yk then "#{format(:e)}#{format(:Gk)}"
       when :YK then "#{format(:e)}#{format(:GK)}"
-      when :f  then "#{format(:e)}#{format(:g)}年#{format(:s)}#{format(:l)}月#{format(:d)}日"
+      when :f  then "#{format(:e)}#{format(:g, opt)}年#{format(:s, opt)}#{format(:l)}月#{format(:d, opt)}日"
       when :F  then "#{format(:e)}#{format(:GK)}年#{format(:Lk)}#{format(:Sk)}月#{format(:Dk)}日"
       end
     end

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -83,10 +83,10 @@ describe Wareki::Date do
 
   it "can be calclated with number" do
     w = Wareki::Date.parse("平成7年11月10日")
-    expect((w + 1).strftime("%Jf")).to eq "平成7年11月11日"
-    expect((w - 1).strftime("%Jf")).to eq "平成7年11月9日"
-    expect((w - 10).strftime("%Jf")).to eq "平成7年10月31日"
-    expect((w + 21).strftime("%Jf")).to eq "平成7年12月1日"
+    expect((w + 1).strftime("%Jf")).to eq "平成07年11月11日"
+    expect((w - 1).strftime("%Jf")).to eq "平成07年11月09日"
+    expect((w - 10).strftime("%Jf")).to eq "平成07年10月31日"
+    expect((w + 21).strftime("%Jf")).to eq "平成07年12月01日"
 
     w = Wareki::Date.today
     expect(w + 1 === Date.today + 1).to eq true
@@ -183,13 +183,24 @@ describe Wareki::Date do
     d = Wareki::Date.new("天和", 3, 5, 4, true)
     expect(d.strftime).to eq "天和三年閏五月四日"
     expect(d.strftime("%JF")).to eq "天和三年閏五月四日"
-    expect(d.strftime("%Jf")).to eq "天和3年5'月4日"
+    expect(d.strftime("%Jf")).to eq "天和03年05'月04日"
     expect(d.strftime("%Jo %JO %JOk")).to eq "1683 １６８３ 千六百八十三"
     expect(d.strftime("%Ji %JI %JIk")).to eq "2343 ２３４３ 二千三百四十三"
-    expect(d.strftime("%Jd %JD %JDk")).to eq "4 ４ 四"
-    expect(d.strftime("%Jm %JM %JMk")).to eq "5' 閏５ 閏五"
-    expect(d.strftime("%Jy %JY %JYk")).to eq "天和3 天和３ 天和三"
-    expect(d.strftime("皇紀で%Ji年%Jm月%Jd日")).to eq "皇紀で2343年5'月4日"
+    expect(d.strftime("%Jd %JD %JDk")).to eq "04 ４ 四"
+    expect(d.strftime("%Jm %JM %JMk")).to eq "05' 閏５ 閏五"
+    expect(d.strftime("%Jy %JY %JYk")).to eq "天和03 天和３ 天和三"
+
+    expect(d.strftime("1桁: %J01f")).to eq "1桁: 天和3年5'月4日"
+    expect(d.strftime("1桁: %J01y %J01m %J01d")).to eq "1桁: 天和3 5' 4"
+    expect(d.strftime("1桁: %J01g %J01s")).to eq "1桁: 3 5"
+    expect(d.strftime("空白2桁: %J_2f")).to eq "空白2桁: 天和 3年 5'月 4日"
+    expect(d.strftime("空白2桁: %J_2y %J_2m %J_2d")).to eq "空白2桁: 天和 3  5'  4"
+    expect(d.strftime("空白2桁: %J_2g %J_2s")).to eq "空白2桁:  3  5"
+    expect(d.strftime("0埋3桁: %J03f")).to eq "0埋3桁: 天和003年005'月004日"
+    expect(d.strftime("0埋3桁: %J03y %J03m %J03d")).to eq "0埋3桁: 天和003 005' 004"
+    expect(d.strftime("0埋3桁: %J03g %J03s")).to eq "0埋3桁: 003 005"
+
+    expect(d.strftime("皇紀で%Ji年%Jm月%Jd日")).to eq "皇紀で2343年05'月04日"
     expect(d.strftime("%JYk年　%JSK")).to eq "天和三年　皐月"
     expect(d.strftime("西暦だと%Y年%m月%d日")).to eq "西暦だと1683年06月28日"
     expect(d.strftime("未定義なやつはそのまま %JeK")).to eq "未定義なやつはそのまま %JeK"
@@ -197,7 +208,7 @@ describe Wareki::Date do
     expect(Wareki::Date.parse("寿永三年 五月 晦日").strftime("%Jd日")).to eq "30日"
     expect(Wareki::Date.parse("寿永2年 3月 晦日").strftime("%Jd日")).to eq "29日"
     expect(Wareki::Date.new("寿永", 2, 3, 29).strftime("%JDK日")).to eq "晦日"
-    expect(Wareki::Date.new("寿永", 1, 2, 1).strftime("%JYK年%Jm月%JDK日")).to eq "寿永元年2月朔日"
+    expect(Wareki::Date.new("寿永", 1, 2, 1).strftime("%JYK年%Jm月%JDK日")).to eq "寿永元年02月朔日"
     expect(Wareki::Date.new("寿永", 1, 1, 1).strftime("%JYK年%JM%JL月%JDK日")).to eq "寿永元年１月元日"
   end
 
@@ -219,7 +230,7 @@ describe Wareki::Date do
 
   it "can parse short era name" do
     {'㍾' => '明治', '㍽' => '大正', '㍼' => '昭和', '㍻' => '平成'}.each do |short, canon|
-      expect(Date.parse("#{short}十年３月9日").strftime('%Jf')).to eq "#{canon}10年3月9日"
+      expect(Date.parse("#{short}十年３月9日").strftime('%Jf')).to eq "#{canon}10年03月09日"
     end
   end
 


### PR DESCRIPTION
issue #11 の件、下記仕様の”数値”部分のみを参考にしてやってみました！ 

https://docs.ruby-lang.org/ja/latest/method/Time/i/strftime.html

> このメソッドは strftime(3) や glibcの仕様を参考に作成されており、以下のオプションが利用できます。
>
>    ^: 大文字で出力を行なう
>    #: 小文字であれば大文字に、大文字であれば小文字に変更する
>    -: 左寄せにする(0埋めや空白埋めを行わない)
>    _: 空白埋めにする
>    0: 0埋めにする
>    数値: 表示桁数を指定する

---

* 大文字/小文字 の変換は不要と思ったので考慮しませんでした。
* 漢数字出力時は、おそらく不要なんではないかと思ってやってません。
* 「皇紀」などちょっとよくわからないので、見ていただけるとありがたいです。
* ドキュメント変更してません～

* ```format``` メソッドの引数 ```opt``` を追加する形にしてみたんですが、もともとの引数 ```key``` に対して各処理が対称にならない感じが、いまいちかと思っております。