### PR TITLE
Allow Date.parse() with no argument as the original does

### DIFF
--- a/lib/wareki/std_ext.rb
+++ b/lib/wareki/std_ext.rb
@@ -24,7 +24,7 @@ class Date
 
   class << self
     alias _wareki_parse_orig parse
-    def parse(str, comp = true, start = ::Date::ITALY)
+    def parse(str = '-4712-01-01', comp = true, start = ::Date::ITALY)
       Wareki::Date.parse(str).to_date(start)
     rescue ArgumentError, Wareki::UnsupportedDateRange
       ::Date._wareki_parse_orig(str, comp, start)

--- a/spec/std_ext_spec.rb
+++ b/spec/std_ext_spec.rb
@@ -6,7 +6,7 @@ describe Wareki::StdExt do
   end
 
   it "overrides parse" do
-    expect(Date.parse()).to eq Date.new(-4712, 1, 1)
+    expect(Date.parse()).to eq Date._wareki_parse_orig()
     expect(Date.parse("平成 二十七年 八月 朔日")).to eq Date.new(2015, 8, 1)
     expect(Date.parse("2015-08-01")).to eq Date.new(2015, 8, 1)
     expect {

--- a/spec/std_ext_spec.rb
+++ b/spec/std_ext_spec.rb
@@ -6,6 +6,7 @@ describe Wareki::StdExt do
   end
 
   it "overrides parse" do
+    expect(Date.parse()).to eq Date.new(-4712, 1, 1)
     expect(Date.parse("平成 二十七年 八月 朔日")).to eq Date.new(2015, 8, 1)
     expect(Date.parse("2015-08-01")).to eq Date.new(2015, 8, 1)
     expect {


### PR DESCRIPTION
(In Japanese)
Date.parseは第1引数が省略可なのでそれを維持するようにします。