### PR TITLE
Override Date._parse in addition to Date.parse

### DIFF
--- a/lib/wareki/common.rb
+++ b/lib/wareki/common.rb
@@ -54,14 +54,14 @@ module Wareki
   )
   NUM_CHARS = '零壱壹弌弐貳貮参參弎肆伍陸漆質柒捌玖〇一二三四五六七八九十拾什卄廿卅丗卌百陌佰皕阡仟千万萬億兆京垓0123456789０１２３４５６７８９'.freeze
   ALT_MONTH_NAME = %w(睦月 如月 弥生 卯月 皐月 水無月 文月 葉月 長月 神無月 霜月 師走).freeze
-  REGEX = %r{^
+  REGEX = %r{
     (?:(?<era_name>紀元前|#{ERA_REGEX})?
       (?:(?<year>[元#{NUM_CHARS}]+)年))?
     (?:(?<is_leap>閏|潤|うるう)?
       (?:(?<month>[正#{NUM_CHARS}]+)月 |
          (?<alt_month>#{ALT_MONTH_NAME.join('|')})))?
     (?:(?<day>[元朔晦#{NUM_CHARS}]+)日|元旦)?
-  $}x.freeze
+  }x.freeze
 
   class UnsupportedDateRange < StandardError; end
 

--- a/lib/wareki/date.rb
+++ b/lib/wareki/date.rb
@@ -26,7 +26,8 @@ module Wareki
 
     def self._parse(str)
       str = str.to_s.gsub(/[[:space:]]/, '')
-      match = (!str.empty? && REGEX.match(str)) or
+      match = REGEX.match(str)
+      match && !match[0].empty? or
         raise ArgumentError, "Invaild Date: #{str}"
       era = match[:era_name]
       if (era.nil? || era == '') && match[:year].nil?

--- a/lib/wareki/std_ext.rb
+++ b/lib/wareki/std_ext.rb
@@ -29,5 +29,15 @@ class Date
     rescue ArgumentError, Wareki::UnsupportedDateRange
       ::Date._wareki_parse_orig(str, comp, start)
     end
+
+    alias _wareki__parse_orig _parse
+    def _parse(str, comp = true)
+      di = Wareki::Date._parse(str)
+      wdate = Wareki::Date.new(di[:era], di[:year], di[:month], di[:day], di[:is_leap])
+    rescue ArgumentError, Wareki::UnsupportedDateRange
+      ::Date._wareki__parse_orig(str, comp)
+    else
+      ::Date._wareki__parse_orig(str.sub(Wareki::REGEX, wdate.strftime('%F ')), comp)
+    end
   end
 end

--- a/spec/std_ext_spec.rb
+++ b/spec/std_ext_spec.rb
@@ -16,6 +16,7 @@ describe Wareki::StdExt do
   it "overrides _parse" do
     expect(Date._parse("平成元年5月4日")).to eq({ year: 1989, mon: 5, mday: 4 })
     expect(Date._parse("平成元年5月4日12:34:56")).to eq({ year: 1989, mon: 5, mday: 4, hour: 12, min: 34, sec: 56 })
+    expect(Date._parse("completely invalid date")).to eq({})
   end
 
   it "have Date::JAPAN" do

--- a/spec/std_ext_spec.rb
+++ b/spec/std_ext_spec.rb
@@ -13,6 +13,11 @@ describe Wareki::StdExt do
     }.to raise_error(ArgumentError)
   end
 
+  it "overrides _parse" do
+    expect(Date._parse("平成元年5月4日")).to eq({ year: 1989, mon: 5, mday: 4 })
+    expect(Date._parse("平成元年5月4日12:34:56")).to eq({ year: 1989, mon: 5, mday: 4, hour: 12, min: 34, sec: 56 })
+  end
+
   it "have Date::JAPAN" do
     expect(Date::JAPAN).to eq Wareki::GREGORIAN_START
   end


### PR DESCRIPTION
Date._parse is the core of Time.parse, so this makes it possible for it to parse a Japanese date with time part.

```ruby
require 'wareki'
require 'time'
Time.parse('令和元年十一月五日 10:00:00') #=> 2019-11-05 10:00:00 +0900
```
