### PR TITLE
Accept use of partially traditional kanji variants

### DIFF
--- a/lib/wareki/common.rb
+++ b/lib/wareki/common.rb
@@ -11,23 +11,52 @@ module Wareki
   IMPERIAL_START_YEAR = -660
   DATE_INFINITY = ::Date.new(280_000_000, 12, 31) # Use 280000000 for jruby limitation...
   YEAR_BY_NUM = Hash[*YEAR_DEFS.map { |y| [y.year, y] }.flatten].freeze
-  ERA_BY_NAME = Hash[*(ERA_NORTH_DEFS + ERA_DEFS).map { |g| [g.name, g] }.flatten]
+  KANJI_VARIANTS = {
+    '宝' => '寳',
+    '霊' => '靈',
+    '神' => '神',
+    '応' => '應',
+    '暦' => '曆',
+    '祥' => '祥',
+    '寿' => '壽',
+    '斎' => '斉',
+    '観' => '觀',
+    '寛' => '寬',
+    '徳' => '德',
+    '禄' => '祿',
+    '万' => '萬',
+    '福' => '福',
+    '禎' => '禎',
+    '国' => '國',
+    '亀' => '龜',
+    '令' => '令',
+  }.freeze
+  SQUARE_ERAS = {
+    '㍾' => '明治',
+    '㍽' => '大正',
+    '㍼' => '昭和',
+    '㍻' => '平成',
+    '㋿' => '令和',
+  }.freeze
+  NORMALIZE_KANJI_VARIANTS_REGEX = Regexp.union(*KANJI_VARIANTS.values)
+  NORMALIZE_KANJI_VARIANTS_HASH = KANJI_VARIANTS.each_with_object({}) { |(n, s), h| s.each_char { |c| h[c] = n } }
+  NORMALIZE_KANJI_VARIANTS = ->(str) { str.gsub(NORMALIZE_KANJI_VARIANTS_REGEX, NORMALIZE_KANJI_VARIANTS_HASH) }
+  ERA_BY_NAME = Hash[*(ERA_NORTH_DEFS + ERA_DEFS).flat_map { |g| [g.name, g] }]
   ERA_BY_NAME['皇紀'] = ERA_BY_NAME['神武天皇即位紀元'] = Era.new('皇紀', -660, 1_480_041, DATE_INFINITY.jd)
   ERA_BY_NAME['西暦'] = ERA_BY_NAME[''] = Era.new('西暦', 1, 1_721_424, DATE_INFINITY.jd)
-  ERA_BY_NAME.keys.each do |era_name|
-    alt_era_name = era_name.tr('宝霊神応暦祥寿斎観寛徳禄万福禎国亀令', '寳靈神應曆祥壽斉觀寬德祿萬福禎國龜令')
-    alt_era_name == era_name and next
-    ERA_BY_NAME[alt_era_name] = ERA_BY_NAME[era_name]
-  end
-  {'㍾' => '明治', '㍽' => '大正', '㍼' => '昭和', '㍻' => '平成', '㋿' => '令和'}.each do |short, canon|
-    ERA_BY_NAME[short] = ERA_BY_NAME[canon]
-  end
+  ERA_BY_NAME.default_proc = ->(hash, key) { hash.fetch(SQUARE_ERAS[key] || NORMALIZE_KANJI_VARIANTS[key], nil) }
   ERA_BY_NAME.freeze
+  ERA_REGEX = Regexp.new(
+    Regexp.union(*ERA_BY_NAME.keys, *SQUARE_ERAS.keys).source.gsub(
+      Regexp.union(*KANJI_VARIANTS.keys),
+      KANJI_VARIANTS.each_with_object({}) { |(canon, variants), h| h[canon] = "[#{canon}#{variants}]" }
+    )
+  )
   NUM_CHARS = '零壱壹弌弐貳貮参參弎肆伍陸漆質柒捌玖〇一二三四五六七八九十拾什卄廿卅丗卌百陌佰皕阡仟千万萬億兆京垓0123456789０１２３４５６７８９'.freeze
   ALT_MONTH_NAME = %w(睦月 如月 弥生 卯月 皐月 水無月 文月 葉月 長月 神無月 霜月 師走).freeze
   REGEX = %r{^
-    (?<era_name>西暦|紀元前|#{ERA_BY_NAME.keys.join('|')})?
-    (?:(?<year>[元#{NUM_CHARS}]+)年)?
+    (?:(?<era_name>紀元前|#{ERA_REGEX})?
+      (?:(?<year>[元#{NUM_CHARS}]+)年))?
     (?:(?<is_leap>閏|潤|うるう)?
       (?:(?<month>[正#{NUM_CHARS}]+)月 |
          (?<alt_month>#{ALT_MONTH_NAME.join('|')})))?

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -149,6 +149,11 @@ describe Wareki::Date do
     expect(d.parse("明治5年12月2日").to_date).to eq Date.new(1872, 12, 31)
     expect(d.parse("令和元年5月2日").to_date).to eq Date.new(2019, 5, 2)
 
+    expect(d.parse("応徳元年九月二十九日").to_date).to eq Date.new(1084, 10, 31)
+    expect(d.parse("応德元年九月二十九日").to_date).to eq Date.new(1084, 10, 31)
+    expect(d.parse("應徳元年九月二十九日").to_date).to eq Date.new(1084, 10, 31)
+    expect(d.parse("應德元年九月二十九日").to_date).to eq Date.new(1084, 10, 31)
+
     expect { d.parse("謎元号100年2月3日") }.to raise_error(ArgumentError)
     expect { d.parse("昭和2月3日") }.to raise_error(ArgumentError)
     expect { d.parse("昭和0年2月3日") }.to raise_error(ArgumentError)


### PR DESCRIPTION
This makes the parser recognize "應徳" as a valid era name, for example.