### PR TITLE
Freeze era definition structs

### DIFF
--- a/lib/wareki/common.rb
+++ b/lib/wareki/common.rb
@@ -44,8 +44,8 @@ module Wareki
   NORMALIZE_KANJI_VARIANTS_HASH = KANJI_VARIANTS.each_with_object({}) { |(n, s), h| s.each_char { |c| h[c] = n } }
   NORMALIZE_KANJI_VARIANTS = ->(str) { str.gsub(NORMALIZE_KANJI_VARIANTS_REGEX, NORMALIZE_KANJI_VARIANTS_HASH) }
   ERA_BY_NAME = Hash[*(ERA_NORTH_DEFS + ERA_DEFS).flat_map { |g| [g.name, g] }]
-  ERA_BY_NAME['皇紀'] = ERA_BY_NAME['神武天皇即位紀元'] = Era.new('皇紀', -660, 1_480_041, DATE_INFINITY.jd)
-  ERA_BY_NAME['西暦'] = ERA_BY_NAME[''] = Era.new('西暦', 1, 1_721_424, DATE_INFINITY.jd)
+  ERA_BY_NAME['皇紀'] = ERA_BY_NAME['神武天皇即位紀元'] = Era.new('皇紀', -660, 1_480_041, DATE_INFINITY.jd).freeze
+  ERA_BY_NAME['西暦'] = ERA_BY_NAME[''] = Era.new('西暦', 1, 1_721_424, DATE_INFINITY.jd).freeze
   ERA_BY_NAME.default_proc = ->(hash, key) { hash.fetch(SQUARE_ERAS[key] || NORMALIZE_KANJI_VARIANTS[key], nil) }
   ERA_BY_NAME.freeze
   # 南北朝期に北朝でのみ使われた元号。歴史上固定のため手書きで保持する。

--- a/lib/wareki/era_def.rb
+++ b/lib/wareki/era_def.rb
@@ -252,7 +252,7 @@ module Wareki
     Era.new("昭和", 1926, 2424875, 2447534),
     Era.new("平成", 1989, 2447535, 2458604),
     Era.new("令和", 2019, 2458605, DAY_MAX),
-  ].freeze
+  ].each(&:freeze).freeze
   ERA_NORTH_DEFS = [
     Era.new("大化", 645, 1956842, 1958551),
     Era.new("白雉", 650, 1958551, 1960259),
@@ -502,5 +502,5 @@ module Wareki
     Era.new("昭和", 1926, 2424875, 2447534),
     Era.new("平成", 1989, 2447535, 2458604),
     Era.new("令和", 2019, 2458605, DAY_MAX),
-  ].freeze
+  ].each(&:freeze).freeze
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -104,4 +104,12 @@ describe Wareki::Utils do
     expect { result = u.i_to_kan(5) }.to output(/DEPRECATED/).to_stderr
     expect(result).to eq '五'
   end
+
+  it 'freezes era definitions' do
+    expect(Wareki::ERA_DEFS).to all(be_frozen)
+    expect(Wareki::ERA_NORTH_DEFS).to all(be_frozen)
+    expect(Wareki::ERA_BY_NAME['皇紀']).to be_frozen
+    expect(Wareki::ERA_BY_NAME['西暦']).to be_frozen
+    expect(u.find_era(Date.new(2019, 5, 1))).to be_frozen
+  end
 end


### PR DESCRIPTION
## Summary

Follow-up to a Copilot review comment on #24: the `ERA_DEFS` / `ERA_NORTH_DEFS` arrays were frozen but the `Era` structs inside were not, so a caller mutating an era returned by `Utils.find_era` or `ERA_BY_NAME` could corrupt process-wide era definitions. This freezes the structs at definition time (including the ad-hoc 皇紀/西暦 entries), which covers every lookup path without adding per-call copies on the conversion hot path.

The `ERA_JD_LOOKUP` builder keeps working as-is since it `dup`s entries before adjusting them (`dup` of a frozen struct is unfrozen); this also stays correct if #24 (which removes that builder) merges in either order.

## Test plan
- TDD: new spec asserting all era definition structs and `find_era` results are frozen, confirmed failing first
- `bundle exec rspec`: 66 examples, 0 failures; RuboCop: no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Pf4Mrtd7zB8Lrjc499t9