### PR TITLE
Adapt to ya_kansuji 1.3.0 fractional-number rendering

### DIFF
--- a/lib/wareki/date.rb
+++ b/lib/wareki/date.rb
@@ -155,6 +155,8 @@ module Wareki
     end
 
     def _validate_date!
+      year.is_a?(Integer) or
+        raise InvalidDate, "invalid date (non-integer year): #{inspect}"
       (month.is_a?(Integer) && month >= 1 && month <= 12) or
         raise InvalidDate, "invalid date (month out of range): #{inspect}"
       (day.is_a?(Integer) && day >= 1) or

--- a/spec/date_spec.rb
+++ b/spec/date_spec.rb
@@ -142,6 +142,16 @@ describe Wareki::Date do
     expect { described_class.new('令和', 2, 5, 4, true) }.to raise_error(ArgumentError, /invalid date/)
   end
 
+  it 'rejects non-integer years' do
+    expect { described_class.new('平成', 1.5) }.to raise_error(Wareki::InvalidDate)
+    expect { described_class.new('', 1989.5) }.to raise_error(Wareki::InvalidDate)
+    expect { described_class.new('平成', 2r) }.to raise_error(Wareki::InvalidDate)
+
+    d = described_class.new('平成', 31, 4, 30)
+    d.year = 2019.5
+    expect { d.jd }.to raise_error(Wareki::InvalidDate)
+  end
+
   it 'leaves the object unchanged when a writer raises' do
     d = described_class.parse('平成7年11月10日')
     expect { d.era_name = '謎元号' }.to raise_error(ArgumentError)

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -152,7 +152,7 @@ describe Wareki::Utils do
     expected = {
       nil => '零',
       '1' => '一',
-      1.5 => '一',
+      1.5 => YaKansuji.to_kan(1.5, :simple),
     }
     allow(YaKansuji).to receive(:to_kan).and_call_original
 


### PR DESCRIPTION
## 概要

ya_kansuji 1.3.0 が小数対応し、`to_kan(1.5, :simple)` が従来の切り捨て (`"一"`) ではなく `"一・五分"` を返すようになったため、CI が失敗していました ([例](https://github.com/sugi/wareki/actions/runs/29641931701/job/88073751106?pr=32))。本 PR で以下の 2 点に対処します。

### 1. spec の期待値をバージョン非依存に (`spec/utils_spec.rb`)

「非整数値の委譲」を検証する example が旧挙動の描画結果 `'一'` をハードコードしていたため、隣接する example と同様に `YaKansuji.to_kan(1.5, :simple)` から期待値を算出するよう変更。ya_kansuji のどのバージョンでもパスします。

### 2. `Wareki::Date` の非整数 year を拒否 (`lib/wareki/date.rb`)

year は month/day と異なり `_validate_date!` で型チェックされておらず、`Wareki::Date.new('平成', 1.5)` のような非整数年は従来「暗黙の切り捨て描画」、ya_kansuji 1.3.0 では小数描画 (`%JF` → `平成一・五分年一月一日`) と、gem のバージョンで挙動が変わる状態でした。month/day の既存 Integer チェックと同様に `Wareki::InvalidDate` を raise するようにします (整数値の Rational も month 同様拒否)。バリデーションのタイミングも既存と同じ initialize 時 + jd 変換時 (setter は遅延) です。

なお、パース方向 (`YaKansuji.to_i`) は 1.3.0 で無変更であり、wareki の捕捉文字クラスに小数単位が含まれないことも確認済みのため、変更は上記のみです。

## テスト

- ya_kansuji 1.3.0 環境で `bundle exec rspec` → 103 examples, 0 failures (変更前は 1 failure)
- rubocop: 新規 offense なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJ7tz3UentFzdZEYpDcZbz